### PR TITLE
fix: duplicate service ids dropped

### DIFF
--- a/lib/application/device/service_repository.dart
+++ b/lib/application/device/service_repository.dart
@@ -3,12 +3,11 @@ import 'package:injectable/injectable.dart';
 import '../../domain/device/service_repository_type.dart';
 import '../../infrastructure/upnp/models/service_description.dart';
 
-@named
-@Singleton(as: ServiceRepositoryType)
-class ServiceRepository extends ServiceRepositoryType {
+@Singleton(as: ServiceDescriptionRepository)
+class InMemoryServiceDescriptionRepository extends ServiceDescriptionRepository {
   Map<String, ServiceDescription> services = {};
   @override
-  ServiceDescription? get(String id) {
+  ServiceDescription? get(String deviceId, String id) {
     if (!services.containsKey(id)) {
       return null;
     }
@@ -17,12 +16,12 @@ class ServiceRepository extends ServiceRepositoryType {
   }
 
   @override
-  bool has(String id) {
+  bool has(String deviceId, String id) {
     return services.containsKey(id);
   }
 
   @override
-  void insert(String id, ServiceDescription service) {
+  void insert(String deviceId, String id, ServiceDescription service) {
     services[id] = service;
   }
 }

--- a/lib/application/device/service_repository.dart
+++ b/lib/application/device/service_repository.dart
@@ -8,20 +8,24 @@ class InMemoryServiceDescriptionRepository extends ServiceDescriptionRepository 
   Map<String, ServiceDescription> services = {};
   @override
   ServiceDescription? get(String deviceId, String id) {
-    if (!services.containsKey(id)) {
+    if (!services.containsKey(_key(deviceId, id))) {
       return null;
     }
 
-    return services[id];
+    return services[_key(deviceId, id)];
   }
 
   @override
   bool has(String deviceId, String id) {
-    return services.containsKey(id);
+    return services.containsKey(_key(deviceId, id));
   }
 
   @override
   void insert(String deviceId, String id, ServiceDescription service) {
-    services[id] = service;
+    services[_key(deviceId, id)] = service;
+  }
+
+  String _key(String deviceId, String id) {
+    return '$deviceId:$id';
   }
 }

--- a/lib/application/ioc.config.dart
+++ b/lib/application/ioc.config.dart
@@ -9,39 +9,52 @@ import 'package:device_info_plus/device_info_plus.dart' as _i4;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
 import 'package:shared_preferences/shared_preferences.dart' as _i12;
+import 'package:upnp_explorer/application/changelog/changelog_service.dart'
+    as _i14;
+import 'package:upnp_explorer/application/device.dart' as _i15;
+import 'package:upnp_explorer/application/device/device_repository.dart' as _i6;
+import 'package:upnp_explorer/application/device/service_repository.dart'
+    as _i11;
+import 'package:upnp_explorer/application/logger_factory.dart' as _i7;
+import 'package:upnp_explorer/application/network_logs/network_logs_repository.dart'
+    as _i9;
+import 'package:upnp_explorer/application/review/review_service.dart' as _i17;
+import 'package:upnp_explorer/application/settings/options_repository.dart'
+    as _i18;
+import 'package:upnp_explorer/domain/device/device_repository_type.dart' as _i5;
+import 'package:upnp_explorer/domain/device/service_repository_type.dart'
+    as _i10;
+import 'package:upnp_explorer/domain/network_logs/network_logs_repository_type.dart'
+    as _i8;
+import 'package:upnp_explorer/infrastructure/core/bug_report_service.dart'
+    as _i3;
+import 'package:upnp_explorer/infrastructure/core/download_service.dart'
+    as _i16;
+import 'package:upnp_explorer/infrastructure/upnp/device_discovery_service.dart'
+    as _i22;
+import 'package:upnp_explorer/infrastructure/upnp/search_request_builder.dart'
+    as _i13;
+import 'package:upnp_explorer/infrastructure/upnp/soap_service.dart' as _i19;
+import 'package:upnp_explorer/infrastructure/upnp/ssdp_discovery.dart' as _i23;
+import 'package:upnp_explorer/presentation/core/bloc/application_bloc.dart'
+    as _i20;
+import 'package:upnp_explorer/presentation/device/bloc/discovery_bloc.dart'
+    as _i24;
+import 'package:upnp_explorer/presentation/service/bloc/command_bloc.dart'
+    as _i21;
 
-import '../domain/device/device_repository_type.dart' as _i5;
-import '../domain/device/service_repository_type.dart' as _i10;
-import '../domain/network_logs/network_logs_repository_type.dart' as _i8;
-import '../infrastructure/core/bug_report_service.dart' as _i3;
-import '../infrastructure/core/download_service.dart' as _i16;
-import '../infrastructure/upnp/device_discovery_service.dart' as _i22;
-import '../infrastructure/upnp/search_request_builder.dart' as _i13;
-import '../infrastructure/upnp/soap_service.dart' as _i19;
-import '../infrastructure/upnp/ssdp_discovery.dart' as _i23;
-import '../presentation/core/bloc/application_bloc.dart' as _i20;
-import '../presentation/device/bloc/discovery_bloc.dart' as _i24;
-import '../presentation/service/bloc/command_bloc.dart' as _i21;
-import 'changelog/changelog_service.dart' as _i14;
-import 'device.dart' as _i15;
-import 'device/device_repository.dart' as _i6;
-import 'device/service_repository.dart' as _i11;
 import 'ioc.dart' as _i25;
-import 'logger_factory.dart' as _i7;
-import 'network_logs/network_logs_repository.dart' as _i9;
-import 'review/review_service.dart' as _i17;
-import 'settings/options_repository.dart'
-    as _i18; // ignore_for_file: unnecessary_lambdas
 
-// ignore_for_file: lines_longer_than_80_chars
-/// initializes the registration of provided dependencies inside of [GetIt]
+/// ignore_for_file: unnecessary_lambdas
+/// ignore_for_file: lines_longer_than_80_chars
+/// initializes the registration of main-scope dependencies inside of [GetIt]
 Future<_i1.GetIt> $initIoc(
-  _i1.GetIt get, {
+  _i1.GetIt getIt, {
   String? environment,
   _i2.EnvironmentFilter? environmentFilter,
 }) async {
   final gh = _i2.GetItHelper(
-    get,
+    getIt,
     environment,
     environmentFilter,
   );
@@ -54,10 +67,8 @@ Future<_i1.GetIt> $initIoc(
   );
   gh.singleton<_i7.LoggerFactory>(_i7.LoggerFactory());
   gh.singleton<_i8.NetworkLogsRepositoryType>(_i9.NetworkLogsRepository());
-  gh.singleton<_i10.ServiceRepositoryType>(
-    _i11.ServiceRepository(),
-    instanceName: 'ServiceRepository',
-  );
+  gh.singleton<_i10.ServiceDescriptionRepository>(
+      _i11.InMemoryServiceDescriptionRepository());
   await gh.factoryAsync<_i12.SharedPreferences>(
     () => registerModule.prefs,
     preResolve: true,
@@ -67,39 +78,41 @@ Future<_i1.GetIt> $initIoc(
     preResolve: true,
   );
   gh.singleton<_i14.ChangelogService>(
-      _i14.ChangelogService(get<_i12.SharedPreferences>()));
-  gh.singletonAsync<_i15.DeviceInfo>(
-      () => _i15.DeviceInfo.create(get<_i4.DeviceInfoPlugin>()));
+      _i14.ChangelogService(gh<_i12.SharedPreferences>()));
+  await gh.singletonAsync<_i15.DeviceInfo>(
+    () => _i15.DeviceInfo.create(gh<_i4.DeviceInfoPlugin>()),
+    preResolve: true,
+  );
   gh.singleton<_i16.DownloadService>(
-      _i16.DownloadService(get<_i7.LoggerFactory>()));
+      _i16.DownloadService(gh<_i7.LoggerFactory>()));
   gh.singleton<_i17.ReviewService>(
-      _i17.ReviewService(get<_i12.SharedPreferences>()));
+      _i17.ReviewService(gh<_i12.SharedPreferences>()));
   gh.singleton<_i13.SearchRequestBuilder>(
-      _i13.SearchRequestBuilder(get<_i13.UserAgentBuilder>()));
+      _i13.SearchRequestBuilder(gh<_i13.UserAgentBuilder>()));
   gh.singleton<_i18.SettingsRepository>(
-      _i18.SettingsRepository(get<_i12.SharedPreferences>()));
+      _i18.SettingsRepository(gh<_i12.SharedPreferences>()));
   gh.singleton<_i19.SoapService>(_i19.SoapService(
-    get<_i13.UserAgentBuilder>(),
-    get<_i8.NetworkLogsRepositoryType>(),
+    gh<_i13.UserAgentBuilder>(),
+    gh<_i8.NetworkLogsRepositoryType>(),
   ));
   gh.singleton<_i20.ApplicationBloc>(
-      _i20.ApplicationBloc(get<_i17.ReviewService>()));
-  gh.singleton<_i21.CommandBloc>(_i21.CommandBloc(get<_i19.SoapService>()));
+      _i20.ApplicationBloc(gh<_i17.ReviewService>()));
+  gh.singleton<_i21.CommandBloc>(_i21.CommandBloc(gh<_i19.SoapService>()));
   gh.singleton<_i22.DeviceDiscoveryService>(_i22.DeviceDiscoveryService(
-    get<_i7.LoggerFactory>(),
-    get<_i8.NetworkLogsRepositoryType>(),
-    get<_i13.SearchRequestBuilder>(),
+    gh<_i7.LoggerFactory>(),
+    gh<_i8.NetworkLogsRepositoryType>(),
+    gh<_i13.SearchRequestBuilder>(),
   ));
   gh.singleton<_i23.SSDPService>(_i23.SSDPService(
-    get<_i22.DeviceDiscoveryService>(),
-    get<_i16.DownloadService>(),
-    get<_i7.LoggerFactory>(),
-    get<_i5.DeviceRepositoryType>(instanceName: 'DeviceRepository'),
-    get<_i10.ServiceRepositoryType>(instanceName: 'ServiceRepository'),
-    get<_i8.NetworkLogsRepositoryType>(),
+    gh<_i22.DeviceDiscoveryService>(),
+    gh<_i16.DownloadService>(),
+    gh<_i7.LoggerFactory>(),
+    gh<_i5.DeviceRepositoryType>(instanceName: 'DeviceRepository'),
+    gh<_i10.ServiceDescriptionRepository>(),
+    gh<_i8.NetworkLogsRepositoryType>(),
   ));
-  gh.singleton<_i24.DiscoveryBloc>(_i24.DiscoveryBloc(get<_i23.SSDPService>()));
-  return get;
+  gh.singleton<_i24.DiscoveryBloc>(_i24.DiscoveryBloc(gh<_i23.SSDPService>()));
+  return getIt;
 }
 
 class _$RegisterModule extends _i25.RegisterModule {}

--- a/lib/application/routing/route_arguments.dart
+++ b/lib/application/routing/route_arguments.dart
@@ -1,0 +1,15 @@
+import '../../infrastructure/upnp/models/device.dart';
+
+class ServiceListPageRouteArgs {
+  final ServiceList serviceList;
+  final String deviceId;
+
+  ServiceListPageRouteArgs(this.serviceList, this.deviceId);
+}
+
+class ServicePageRouteArgs {
+  final Service service;
+  final String deviceId;
+
+  ServicePageRouteArgs(this.service, this.deviceId);
+}

--- a/lib/application/routing/route_handlers.dart
+++ b/lib/application/routing/route_handlers.dart
@@ -1,4 +1,5 @@
 import 'package:fluro/fluro.dart';
+import 'package:upnp_explorer/application/routing/route_arguments.dart';
 import 'package:xml/xml.dart';
 
 import '../../domain/device/service_repository_type.dart';
@@ -34,10 +35,11 @@ var deviceHandler = Handler(handlerFunc: (context, params) {
 });
 
 var serviceListHandler = Handler(handlerFunc: (context, _) {
-  final args = context!.settings!.arguments as ServiceList;
+  final args = context!.settings!.arguments as ServiceListPageRouteArgs;
 
   return ServiceListPage(
-    services: args,
+    services: args.serviceList,
+    deviceId: args.deviceId,
   );
 });
 
@@ -50,13 +52,15 @@ var deviceListHandler = Handler(handlerFunc: (context, _) {
 });
 
 var serviceHandler = Handler(handlerFunc: (context, params) {
+  final args = context!.settings!.arguments as ServicePageRouteArgs;
+
   final id = params['id']![0];
 
-  final repo = sl.get<ServiceRepositoryType>(instanceName: 'ServiceRepository');
+  final repo = sl.get<ServiceDescriptionRepository>();
 
   return ServicePage(
-    description: repo.get(id)!,
-    service: context!.settings!.arguments as Service,
+    description: repo.get(args.deviceId, id)!,
+    service: args.service,
   );
 });
 

--- a/lib/domain/device/service_repository_type.dart
+++ b/lib/domain/device/service_repository_type.dart
@@ -1,7 +1,7 @@
 import '../../infrastructure/upnp/models/service_description.dart';
 
-abstract class ServiceRepositoryType {
-  ServiceDescription? get(String id);
-  bool has(String id);
-  void insert(String id, ServiceDescription service);
+abstract class ServiceDescriptionRepository {
+  ServiceDescription? get(String deviceId, String id);
+  bool has(String deviceId, String id);
+  void insert(String deviceId, String id, ServiceDescription service);
 }

--- a/lib/infrastructure/upnp/models/device.dart
+++ b/lib/infrastructure/upnp/models/device.dart
@@ -37,20 +37,53 @@ class DeviceDescription {
 }
 
 class Device {
+  /// UPnP device type.
   final _DeviceType deviceType;
+
+  /// Short description for end user.
   final String friendlyName;
+
+  /// Manufacturer's name.
   final String manufacturer;
+
+  /// Web site for [manufacturer].
   final Uri? manufacturerUrl;
+
+  /// Long description for end user.
   final String? modelDescription;
+
+  /// Model name.
   final String modelName;
+
+  /// Model number.
   final String? modelNumber;
+
+  /// Web site for model.
   final Uri? modelUrl;
+
+  /// Serial number.
   final String? serialNumber;
+
+  /// Unique device name.
+  ///
+  /// A universally-unique identifier for the device, whether root or embedded.
   final String udn;
+
+  /// Universal product code.
+  ///
+  /// A 12-digit, all numeric code that identifies the consumer packages.
   final String? upc;
+
+  /// List of icons that visually represent this device.
   final _IconList iconList;
+
+  /// List of services available on this device.
   final ServiceList serviceList;
+
+  /// List of child devices on this device.
   final DeviceList deviceList;
+
+  /// URL to presentation for this device.
   final Uri? presentationUrl;
 
   Device({
@@ -71,7 +104,15 @@ class Device {
     this.presentationUrl,
   });
 
-  static fromXml(XmlNode xml) {
+  static List<Device> listFromXmlNode(XmlNode? xml) {
+    return xml
+            ?.findAllElements('device')
+            .map<Device>((e) => Device.fromXml(e))
+            .toList() ??
+        [];
+  }
+
+  static Device fromXml(XmlNode xml) {
     final presentationUrl = xml.getElement('presentationURL');
 
     final modelUrl = xml.getElement('modelURL');
@@ -121,6 +162,7 @@ class _DeviceType {
   }
 }
 
+@deprecated
 class DeviceList {
   final List<Device> devices;
 
@@ -139,6 +181,7 @@ class DeviceList {
   }
 }
 
+@deprecated
 class ServiceList {
   final List<Service> services;
 
@@ -158,11 +201,22 @@ class ServiceList {
 }
 
 class Service {
+  /// UPnP service type.
   final String serviceType;
+
+  ///
   final String serviceVersion;
+
+  /// Service identifier.
   final _ServiceId serviceId;
+
+  /// URL for service description.
   final Uri scpdurl;
+
+  /// URL for control.
   final Uri controlUrl;
+
+  /// URL for eventing.
   final Uri eventSubUrl;
 
   Service({
@@ -174,7 +228,15 @@ class Service {
     required this.eventSubUrl,
   });
 
-  static fromXml(XmlNode xml) {
+  static List<Service> listFromXmlNode(XmlNode? xml) {
+    return xml
+            ?.findAllElements('service')
+            .map<Service>((x) => Service.fromXml(x))
+            .toList() ??
+        [];
+  }
+
+  static Service fromXml(XmlNode xml) {
     final scpdurl = xml.getElement('SCPDURL')?.text;
     final controlUrl = xml.getElement('controlURL')?.text;
     final eventSubUrl = xml.getElement('eventSubURL')?.text;
@@ -220,6 +282,7 @@ class _ServiceId {
   }
 }
 
+@deprecated
 class _IconList {
   final List<DeviceIcon> icons;
 
@@ -239,10 +302,21 @@ class _IconList {
 }
 
 class DeviceIcon {
+  /// Icon's MIME type.
   final String mimeType;
+
+  /// Horizontal dimension of the icon, in pixels.
   final int width;
+
+  /// Vertical dimensions of the icon, in pixels.
   final int height;
+
+  /// Number of color bits per pixel.
   final String depth;
+
+  /// Pointer to the icon image.
+  ///
+  /// Relative to the URL at which the device description is located.
   final Uri url;
 
   DeviceIcon({
@@ -253,7 +327,15 @@ class DeviceIcon {
     required this.url,
   });
 
-  static fromXml(XmlNode xml) {
+  static List<DeviceIcon> listFromXmlNode(XmlNode? xml) {
+    return xml
+            ?.findAllElements('icon')
+            .map<DeviceIcon>((x) => DeviceIcon.fromXml(x))
+            .toList() ??
+        [];
+  }
+
+  static DeviceIcon fromXml(XmlNode xml) {
     return DeviceIcon(
       mimeType: xml.getElement('mimetype')!.text,
       width: int.parse(xml.getElement('width')!.text),

--- a/lib/infrastructure/upnp/ssdp_discovery.dart
+++ b/lib/infrastructure/upnp/ssdp_discovery.dart
@@ -32,7 +32,7 @@ class SSDPService {
   final DeviceDiscoveryService discovery;
   final Logger logger;
   final DeviceRepositoryType deviceRepository;
-  final ServiceRepositoryType serviceRepository;
+  final ServiceDescriptionRepository serviceRepository;
   final NetworkLogsRepositoryType trafficRepository;
 
   final List<Object> seen = [];
@@ -44,7 +44,7 @@ class SSDPService {
     this.download,
     LoggerFactory loggerFactory,
     @Named('DeviceRepository') this.deviceRepository,
-    @Named('ServiceRepository') this.serviceRepository,
+    this.serviceRepository,
     this.trafficRepository,
   ) : logger = loggerFactory.build('SSDPService');
 
@@ -69,6 +69,7 @@ class SSDPService {
           XmlDocument.parse(response.body),
         );
         serviceRepository.insert(
+          device.udn,
           service.serviceId.toString(),
           serviceDescription,
         );

--- a/lib/presentation/device/pages/device_page.dart
+++ b/lib/presentation/device/pages/device_page.dart
@@ -4,6 +4,7 @@ import 'package:xml/xml.dart';
 
 import '../../../application/application.dart';
 import '../../../application/l10n/generated/l10n.dart';
+import '../../../application/routing/route_arguments.dart';
 import '../../../application/routing/routes.dart';
 import '../../../infrastructure/upnp/models/device.dart';
 import '../../../infrastructure/upnp/ssdp_response_message.dart';
@@ -150,7 +151,12 @@ class DevicePage extends StatelessWidget {
                   onTap: () => Application.router!.navigateTo(
                     context,
                     Routes.serviceList,
-                    routeSettings: RouteSettings(arguments: device.serviceList),
+                    routeSettings: RouteSettings(
+                      arguments: ServiceListPageRouteArgs(
+                        device.serviceList,
+                        device.udn,
+                      ),
+                    ),
                   ),
                 ),
               if (device.deviceList.devices.isNotEmpty)

--- a/lib/presentation/device/pages/service_list_page.dart
+++ b/lib/presentation/device/pages/service_list_page.dart
@@ -5,23 +5,26 @@ import 'package:upnp_explorer/presentation/core/page/app_page.dart';
 import '../../../application/application.dart';
 import '../../../application/ioc.dart';
 import '../../../application/l10n/generated/l10n.dart';
+import '../../../application/routing/route_arguments.dart';
 import '../../../application/routing/routes.dart';
 import '../../../domain/device/service_repository_type.dart';
 import '../../../infrastructure/upnp/models/device.dart';
 import '../../service/bloc/command_bloc.dart';
 
 class ServiceListPage extends StatelessWidget {
+  final String deviceId;
   final ServiceList services;
-  final ServiceRepositoryType repo =
-      sl<ServiceRepositoryType>(instanceName: 'ServiceRepository');
+  final ServiceDescriptionRepository repo =
+      sl<ServiceDescriptionRepository>();
 
   ServiceListPage({
     Key? key,
     required this.services,
+    required this.deviceId,
   }) : super(key: key);
 
   VoidCallback? _navigateToService(BuildContext context, Service service) {
-    if (!repo.has(service.serviceId.toString())) {
+    if (!repo.has(deviceId, service.serviceId.toString())) {
       return null;
     }
 
@@ -30,7 +33,12 @@ class ServiceListPage extends StatelessWidget {
       Application.router!.navigateTo(
         context,
         Routes.service(service.serviceId.toString()),
-        routeSettings: RouteSettings(arguments: service),
+        routeSettings: RouteSettings(
+          arguments: ServicePageRouteArgs(
+            service,
+            deviceId,
+          ),
+        ),
       );
     };
   }

--- a/lib/presentation/service/widgets/action_output.dart
+++ b/lib/presentation/service/widgets/action_output.dart
@@ -74,7 +74,7 @@ class ArgumentOutput extends StatelessWidget {
     showDialog(
       context: context,
       builder: (context) => SimpleDialog(
-        contentPadding: const EdgeInsets.fromLTRB(24, 12, 8, 16),
+        contentPadding: const EdgeInsets.fromLTRB(24, 12, 16, 16),
         title: Text(name),
         children: [
           Text(text),


### PR DESCRIPTION
The `ServiceId` field is only unique within a single device description. The repository that holds all service description information used only the `ServiceId` as the key to access the description. As such, when multiple devices contain the same `ServiceId`, the former device's services descriptions get dropped in favor of the latter-most device.

This change fixes this behavior by calculating an effective service ID by combining the devcie's `udn` and the service ID.