### PR TITLE
Patch ActionResponse to find first XmlElement

### DIFF
--- a/lib/packages/upnp/src/control.dart
+++ b/lib/packages/upnp/src/control.dart
@@ -20,7 +20,7 @@ class ActionResponse {
     final Map<String, String> arguments = {};
     final xml = XmlDocument.parse(str);
     final node =
-        xml.rootElement.getElement('s:Body')!.children.first as XmlElement;
+        xml.rootElement.getElement('s:Body')!.children.firstWhere((el) => el is XmlElement) as XmlElement;
 
     node.children.whereType<XmlElement>().forEach(
           (x) => arguments[x.localName] = x.innerText,


### PR DESCRIPTION
Fixes #65 

I found the issue.

My TV was sending back this XML:
```xml
I/flutter (32409): <s:Envelope
I/flutter (32409): xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
I/flutter (32409): <s:Body>
I/flutter (32409): <u:ListPresetsResponse xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1">
I/flutter (32409): <CurrentPresetNameList>FactoryDefaults,silent,normal,loud</CurrentPresetNameList>
I/flutter (32409): </u:ListPresetsResponse>
I/flutter (32409): </s:Body>
I/flutter (32409): </s:Envelope>
```

The xml is fine, but it has a bunch of new line characters. The devices that work send back XML as a one line string.

You had `xml.rootElement.getElement('s:Body')!.children.first as XmlElement;` which was grabbing the whitespace in the above xml. So it was throwing an error saying something like "can't cast XmlText to XmlElement"

I was able to fix it by just grabbing the first xml element using `firstWhere`.