### PR TITLE
Forward fault responses to ActionFault

### DIFF
--- a/lib/packages/upnp/src/control.dart
+++ b/lib/packages/upnp/src/control.dart
@@ -22,6 +22,10 @@ class ActionResponse {
     final node =
         xml.rootElement.getElement('s:Body')!.children.first as XmlElement;
 
+    if (node.localName == "Fault") {
+      throw "Parse the fault with ActionFault";
+    }
+
     node.children.whereType<XmlElement>().forEach(
           (x) => arguments[x.localName] = x.innerText,
         );

--- a/lib/presentation/service/pages/action_page.dart
+++ b/lib/presentation/service/pages/action_page.dart
@@ -56,13 +56,13 @@ class _ActionPageState extends State<ActionPage> {
         _results = result.arguments;
       });
     } on ActionInvocationError catch (e) {
-      _onCommandError(context, e.code);
+      _onCommandError(context, e.code, e.description);
     }
   }
 
-  void _onCommandError(BuildContext context, String code) {
+  void _onCommandError(BuildContext context, String code, String message) {
     final snackbar = SnackBar(
-      content: Text(AppLocalizations.of(context)!.commandFailedWithError(code)),
+      content: Text(AppLocalizations.of(context)!.commandFailedWithError('$code: $message')),
     );
     ScaffoldMessenger.of(context).showSnackBar(snackbar);
   }
@@ -108,9 +108,9 @@ class _ActionPageState extends State<ActionPage> {
                     onPressed: () => Navigator.of(context).pop(),
                   ),
                   title: FittedBox(
-                    child: 
+                    child:
                       Text(widget.action.name),
-                    
+
                   ),
                 ),
                 SliverList(


### PR DESCRIPTION
One of the commands on my SmartTV returns a "Not Implemented" fault.

This XML goes through the `ActionResponse`, it's all valid XML so the response is returned, but nothing shows up in the UI because the only keys in the response are the fault details, not the expected output.

This patch catches faults in `ActionResponse.parse` and forwards them to the `ActionFault` parser. Now the fault toast shows up. I also added the `errorDescription` field of the fault response to the toast. `Command failed 602` is not as helpful as `Command failed 602: Optional Action Not Implemented`