### PR TITLE
fix: target SDK 33

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,7 +42,7 @@ android {
     defaultConfig {
         applicationId "com.samueljhuf.upnp_explorer"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
## What?
I updated the Android manifest to target SDK 33.

## Why?
This change is required by Google to keep the app on the Play Store. See [here](https://developer.android.com/google/play/requirements/target-sdk).

## How?
This is a relatively simple change; I bumped the `targetSdkVersion` in `build.gradle` from `31` to `33`.

## Testing?
I tested to make sure the app still built and ran on Android devices.

## Screenshots (optional)
N/A.

## Anything Else?
N/A.

*Based on [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
