### PR TITLE
fix: update options in UPnP server

### DIFF
--- a/lib/application/ioc.dart
+++ b/lib/application/ioc.dart
@@ -35,8 +35,14 @@ abstract class RegisterModule {
     SettingsRepository settingsRepo,
   ) async {
     final i = SimpleUPNP.instance();
+    final settings = settingsRepo.get();
 
-    await i.start(Options());
+    await i.start(Options(
+      ipv4: true,
+      ipv6: true,
+      multicastHops: settings.protocolOptions.hops,
+      maxDelay: settings.protocolOptions.maxDelay,
+    ));
 
     return i;
   }

--- a/lib/application/settings/options_repository.dart
+++ b/lib/application/settings/options_repository.dart
@@ -23,8 +23,8 @@ class SettingsRepository {
 
   SettingsRepository(this.preferences);
 
-  set(Settings options) async {
-    await Future.wait([
+  Future<void> set(Settings options) async {
+    return await Future.wait([
       preferences.setString(
         _kThemeKey,
         options.themeMode.name,
@@ -49,7 +49,7 @@ class SettingsRepository {
         _kAdvanced,
         options.protocolOptions.advanced,
       ),
-    ]);
+    ]).then((v) => {});
   }
 
   Settings get() {

--- a/lib/libraries/simple_upnp/src/discovery.dart
+++ b/lib/libraries/simple_upnp/src/discovery.dart
@@ -98,7 +98,6 @@ class SSDPDiscovery {
     });
 
     await Future.wait([
-      _events.close(),
       _notify.close(),
     ]);
   }

--- a/lib/libraries/simple_upnp/src/options.dart
+++ b/lib/libraries/simple_upnp/src/options.dart
@@ -32,6 +32,16 @@ class Options {
       maxDelay: 3,
     );
   }
+
+  @override
+  String toString() {
+    return '''
+ipv4: ${ipv4}
+ipv6: ${ipv6}
+multicast_hops: ${multicastHops}
+max_delay: ${maxDelay}
+''';
+  }
 }
 
 class StaticOptions {

--- a/lib/libraries/simple_upnp/src/upnp.dart
+++ b/lib/libraries/simple_upnp/src/upnp.dart
@@ -46,7 +46,7 @@ class SimpleUPNP {
     return _instance ??= SimpleUPNP._();
   }
 
-  late final Options _options;
+  Options _options = Options.base();
   late final StaticOptions _staticOptions;
   final StreamController<UPnPEvent> _events = StreamController.broadcast();
   State _state = State.uninitialized;
@@ -84,6 +84,14 @@ class SimpleUPNP {
     );
   }
 
+  Future<void> update(Options options) async {
+    print('Updating options: ${options}');
+    _options = options;
+
+    await _discovery.stop();
+    await _discovery.start(_options);
+  }
+
   Future<void> start(Options options) async {
     if (_state != State.uninitialized) {
       throw InvalidStateError(_state, State.uninitialized);
@@ -110,6 +118,7 @@ class SimpleUPNP {
 
     _discovery.search(searchTarget);
 
+    print('Delaying ${_options.maxDelay}');
     return Future.delayed(Duration(seconds: _options.maxDelay)).then((_) {
       _state = State.ready;
     });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:upnp_explorer/libraries/simple_upnp/src/upnp.dart';
+import 'package:upnp_explorer/presentation/device/pages/service.dart';
 
 import 'application/application.dart';
 import 'application/ioc.dart';
@@ -21,7 +23,10 @@ void main() {
       ModelBinding(
         initialModel: sl<SettingsRepository>().get(),
         onUpdate: (m) {
-          sl<SettingsRepository>().set(m);
+          sl<SettingsRepository>().set(m).then((_) async {
+            final svc = sl<DiscoveryStateService>();
+            await svc.update(m.protocolOptions);
+          });
         },
         child: MyApp(
           optionsRepository: sl(),

--- a/lib/presentation/device/pages/service.dart
+++ b/lib/presentation/device/pages/service.dart
@@ -1,6 +1,7 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:injectable/injectable.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:upnp_explorer/application/settings/options.dart';
 
 import '../../../libraries/simple_upnp/simple_upnp.dart';
 import 'state.dart';
@@ -67,6 +68,17 @@ class DiscoveryStateService {
           ),
         );
       },
+    );
+  }
+
+  Future<void> update(ProtocolSettings settings) async {
+    _subject.add(_value.copyWith(devices: []));
+    await _upnp.update(
+      Options(
+          ipv4: true,
+          ipv6: true,
+          multicastHops: settings.hops,
+          maxDelay: settings.maxDelay),
     );
   }
 

--- a/lib/presentation/settings/pages/protocol/maximum_response_delay_page.dart
+++ b/lib/presentation/settings/pages/protocol/maximum_response_delay_page.dart
@@ -38,8 +38,8 @@ class _MaximumResponseDelayPageState extends State<MaximumResponseDelayPage> {
     final options = Settings.of(context);
     final advanced = options.protocolOptions.advanced;
 
-    return WillPopScope(
-      onWillPop: () {
+    return PopScope(
+      onPopInvoked: (_) {
         Settings.update(
           context,
           options.copyWith(
@@ -49,7 +49,6 @@ class _MaximumResponseDelayPageState extends State<MaximumResponseDelayPage> {
             ),
           ),
         );
-        return Future.value(true);
       },
       child: SettingsCategoryPage(
         category: i18n.maxResponseDelay,

--- a/lib/presentation/settings/pages/protocol/multicast_hops_page.dart
+++ b/lib/presentation/settings/pages/protocol/multicast_hops_page.dart
@@ -33,15 +33,14 @@ class _MulticastHopsPageState extends State<MulticastHopsPage> {
     final i18n = AppLocalizations.of(context)!;
     final options = Settings.of(context);
 
-    return WillPopScope(
-      onWillPop: () {
+    return PopScope(
+      onPopInvoked: (_) {
         Settings.update(
           context,
           options.copyWith(
             protocolOptions: options.protocolOptions.copyWith(hops: _hops),
           ),
         );
-        return Future.value(true);
       },
       child: SettingsCategoryPage(
         category: i18n.multicastHops,


### PR DESCRIPTION
## What?
Properly pass scan options to the UPnP server.

## Why?
Supports customizing how the UPnP scan is executed.

## How?
I implemented an update method that is called on startup and whenever the settings are updated in the UI.

## Testing?
Tested on a physical device.

## Screenshots (optional)
N/A.

## Anything Else?
N/A.

*Based on [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
