### PR TITLE
chore(android): bump min sdk version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -66,7 +66,7 @@ android {
     defaultConfig {
         applicationId "com.samueljhuf.upnp_explorer"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
Bump the android min SDK version to 35 for Google Play compliance.